### PR TITLE
feat:Add the metadata interface to the reporter class

### DIFF
--- a/snakemake_interface_report_plugins/interfaces.py
+++ b/snakemake_interface_report_plugins/interfaces.py
@@ -25,6 +25,13 @@ class CategoryInterface(ABC):
     def id(self) -> str: ...
 
 
+class MetadataRecordInterface(ABC):
+
+    @property
+    @abstractmethod
+    def parse_yte(self) -> dict: ...
+
+
 class RuleRecordInterface(ABC):
     @property
     @abstractmethod

--- a/snakemake_interface_report_plugins/reporter.py
+++ b/snakemake_interface_report_plugins/reporter.py
@@ -11,6 +11,7 @@ from snakemake_interface_report_plugins.interfaces import (
     ConfigFileRecordInterface,
     JobRecordInterface,
     RuleRecordInterface,
+    MetadataRecordInterface,
 )
 from snakemake_interface_report_plugins.settings import ReportSettingsBase
 from snakemake_interface_report_plugins.interfaces import DAGReportInterface
@@ -27,6 +28,7 @@ class ReporterBase(ABC):
         jobs: List[JobRecordInterface],
         settings: ReportSettingsBase,
         workflow_description: str,
+        metadata: MetadataRecordInterface,
         dag: DAGReportInterface,
     ):
         self.rules = rules
@@ -35,6 +37,7 @@ class ReporterBase(ABC):
         self.configfiles = configfiles
         self.settings = settings
         self.workflow_description = workflow_description
+        self.metadata = metadata
         self.dag = dag
 
         self.__post_init__()


### PR DESCRIPTION
This is required, to allow custom metadata in the report (https://github.com/snakemake/snakemake/pull/3452).